### PR TITLE
Allow sending of request body for POST, PUT, and DELETE

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -281,7 +281,7 @@ element.
       go: function() {
         var args = this.xhrArgs || {};
         // TODO(sjmiles): alternatively, we could force POST if body is set
-        if (this.method === 'POST') {
+        if (/^(POST|PUT|DELETE)$/.test(this.method)) {
           args.body = this.body || args.body;
         }
         args.params = this.params || args.params;

--- a/core-xhr.html
+++ b/core-xhr.html
@@ -98,7 +98,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         this.makeReadyStateHandler(xhr, options.callback);
         this.setRequestHeaders(xhr, options.headers);
-        xhr.send(method == 'POST' ? (options.body || params) : null);
+        var bodyAllowed = /^(POST|PUT|DELETE)$/.test(method);
+        xhr.send(bodyAllowed ? (options.body || params) : null);
         if (!async) {
           xhr.onreadystatechange(xhr);
         }


### PR DESCRIPTION
This allows one to set a body when using POST, PUT, or DELETE.  Before the body was only send for a POST request.
