### PR TITLE
GET params not added to query string if method is "get"

### DIFF
--- a/core-xhr.html
+++ b/core-xhr.html
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var async = !options.sync;
         //
         var params = this.toQueryString(options.params);
-        if (params && method == 'GET') {
+        if (params && method.toUpperCase() == 'GET') {
           url += (url.indexOf('?') > 0 ? '&' : '?') + params;
         }
         var xhrParams = this.isBodyMethod(method) ? (options.body || params) : null;


### PR DESCRIPTION
If the method is set to "get" (instead of "GET") via the options, params will not be URL encoded and included as query parameters in the URI.  Case should not be a factor when checking the method of the request.
