### PR TITLE
Prevent adding 'content-type' header if one already exists

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -307,7 +307,7 @@ element.
         return header.toLowerCase() === 'content-type';
       });
       if (!hasContentType && this.contentType) {
-        args.headers['content-type'] = this.contentType;
+        args.headers['Content-Type'] = this.contentType;
       }
       if (this.handleAs === 'arraybuffer' || this.handleAs === 'blob' ||
           this.handleAs === 'document') {

--- a/core-ajax.html
+++ b/core-ajax.html
@@ -303,7 +303,10 @@ element.
       if (args.headers && typeof(args.headers) == 'string') {
         args.headers = JSON.parse(args.headers);
       }
-      if (this.contentType) {
+      var hasContentType = Object.keys(args.headers).some(function (header) {
+        return header.toLowerCase() === 'content-type';
+      });
+      if (!hasContentType && this.contentType) {
         args.headers['content-type'] = this.contentType;
       }
       if (this.handleAs === 'arraybuffer' || this.handleAs === 'blob' ||


### PR DESCRIPTION
Fixes #19
- Added a `hasContentType` boolean to determine whether a `'Content-Type'` header already exists. (Should this be a helper function instead?)
- Renamed `args.headers['content-type']` to `args.headers['Content-Type']` because header names conventionally have the first letter of each word capitalized. [Sometimes lowercase can cause issues](https://github.com/cjohansen/Sinon.JS/issues/547).
