### PR TITLE
Add support complexe object into queryParams

### DIFF
--- a/core-xhr.html
+++ b/core-xhr.html
@@ -71,12 +71,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         return xhr;
       },
-    
+
       toQueryString: function(params) {
         var r = [];
         for (var n in params) {
           var v = params[n];
-          n = encodeURIComponent(n);
+          n = encodeURIComponent(JSON.stringify(n));
           r.push(v == null ? n : (n + '=' + encodeURIComponent(v)));
         }
         return r.join('&');
@@ -85,7 +85,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       isBodyMethod: function(method) {
         return this.bodyMethods[(method || '').toUpperCase()];
       },
-      
+
       bodyMethods: {
         POST: 1,
         PUT: 1,
@@ -111,5 +111,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
   </script>
-  
+
 </polymer-element>

--- a/core-xhr.html
+++ b/core-xhr.html
@@ -76,12 +76,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var r = [];
         for (var n in params) {
           var v = params[n];
-          n = encodeURIComponent(JSON.stringify(n));
-          r.push(v == null ? n : (n + '=' + encodeURIComponent(v)));
+          n = encodeURIComponent(n);
+          if(v == null){
+            r.push(n);
+          }else{
+            v = this.isString(v) ? v : JSON.stringify(v);
+            r.push(n + '=' + encodeURIComponent(v));
+          }
         }
         return r.join('&');
       },
-
+      isString:function(str){
+        return str instanceof String ||
+               typeof str === 'string';
+      },
       isBodyMethod: function(method) {
         return this.bodyMethods[(method || '').toUpperCase()];
       },

--- a/tests/html/core-ajax-arrays.html
+++ b/tests/html/core-ajax-arrays.html
@@ -21,37 +21,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 
   <core-ajax
-    id="simple"
+    id="arrays"
     url="http://gdata.youtube.com/feeds/api/videos/"
-    params='{"alt":"json", "q":"chrome"}'
+    params='{"alt":"json","key1": ["a","b","c"]}'
     handleAs="json"
     auto>
   </core-ajax>
-<!--
-  <core-ajax
-    id="arrays"
-    url="http://gdata.youtube.com/feeds/api/videos/"
-    params='{"key1": ["a","b","c"]}'
-    handleAs="json"
-    auto>
-  </core-ajax> -->
 
   <script>
 
     document.addEventListener('polymer-ready', function() {
-      var assert = chai.assert;
-      var simpleAjax = document.querySelector('core-ajax#simple');
-      simpleAjax.addEventListener("core-response", function(event) {
+
+      var arraysAjax = document.querySelector('core-ajax#arrays');
+      arraysAjax.addEventListener("core-response", function(event) {
         chai.assert.isTrue(event.detail.response.feed.entry.length > 0);
+        chai.assert.equal(event.detail.xhr.responseURL, "http://gdata.youtube.com/feeds/api/videos/?alt=json&key1=" + encodeURIComponent(JSON.stringify(["a","b","c"])));
         done();
       });
-
-
-      // var arraysAjax = document.querySelector('core-ajax#arrays');
-      // arraysAjax.addEventListener("core-response", function(event) {
-      //   assert.isTrue(event.detail.response.feed.entry.length > 0);
-      //   done();
-      // });
 
     });
 

--- a/tests/html/core-ajax-complexe-object.html
+++ b/tests/html/core-ajax-complexe-object.html
@@ -21,38 +21,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 
   <core-ajax
-    id="simple"
+    id="multi-level"
     url="http://gdata.youtube.com/feeds/api/videos/"
-    params='{"alt":"json", "q":"chrome"}'
+    params='{"alt":"json","key1": {"key21":{"key211":"value211"}}}'
     handleAs="json"
     auto>
   </core-ajax>
-<!--
-  <core-ajax
-    id="arrays"
-    url="http://gdata.youtube.com/feeds/api/videos/"
-    params='{"key1": ["a","b","c"]}'
-    handleAs="json"
-    auto>
-  </core-ajax> -->
-
   <script>
 
     document.addEventListener('polymer-ready', function() {
-      var assert = chai.assert;
-      var simpleAjax = document.querySelector('core-ajax#simple');
-      simpleAjax.addEventListener("core-response", function(event) {
-        chai.assert.isTrue(event.detail.response.feed.entry.length > 0);
+
+      var multiLevelAjax = document.querySelector('core-ajax#multi-level');
+      multiLevelAjax.addEventListener("core-response", function(event) {
+        chai.assert.equal(event.detail.xhr.responseURL, "http://gdata.youtube.com/feeds/api/videos/?alt=json&key1=" + encodeURIComponent(JSON.stringify({"key21":{"key211":"value211"}})));
         done();
       });
-
-
-      // var arraysAjax = document.querySelector('core-ajax#arrays');
-      // arraysAjax.addEventListener("core-response", function(event) {
-      //   assert.isTrue(event.detail.response.feed.entry.length > 0);
-      //   done();
-      // });
-
     });
 
   </script>

--- a/tests/html/core-ajax.html
+++ b/tests/html/core-ajax.html
@@ -21,20 +21,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 
   <core-ajax
+    id="simple"
     url="http://gdata.youtube.com/feeds/api/videos/"
     params='{"alt":"json", "q":"chrome"}'
     handleAs="json"
-    auto></core-ajax>
+    auto>
+  </core-ajax>
+
+  <core-ajax
+    id="multi-level"
+    url="http://gdata.youtube.com/feeds/api/videos/"
+    params='{"key1": {"key11":"value11"}, "key2": {"key21":{"key211":"value211"}}}'
+    handleAs="json"
+    auto>
+  </core-ajax>
+
+  <core-ajax
+    id="arrays"
+    url="http://gdata.youtube.com/feeds/api/videos/"
+    params='{"key1": ["a","b","c"]}'
+    handleAs="json"
+    auto>
+  </core-ajax>
 
   <script>
 
     document.addEventListener('polymer-ready', function() {
       var assert = chai.assert;
-      var ajax = document.querySelector('core-ajax');
-      ajax.addEventListener("core-response", function(event) {
+      var simpleAjax = document.querySelector('core-ajax#simple');
+      simpleAjax.addEventListener("core-response", function(event) {
         assert.isTrue(event.detail.response.feed.entry.length > 0);
         done();
       });
+
+      var multiLevelAjax = document.querySelector('core-ajax#multi-level');
+      multiLevelAjax.addEventListener("core-response", function(event) {
+        assert.isTrue(event.detail.response.feed.entry.length > 0);
+        done();
+      });
+
+      var arraysAjax = document.querySelector('core-ajax#arrays');
+      arraysAjax.addEventListener("core-response", function(event) {
+        assert.isTrue(event.detail.response.feed.entry.length > 0);
+        done();
+      });
+
     });
 
   </script>

--- a/tests/js/htmltests.js
+++ b/tests/js/htmltests.js
@@ -1,3 +1,5 @@
 htmlSuite('core-ajax', function() {
   htmlTest('html/core-ajax.html');
+  htmlTest('html/core-ajax-complexe-object.html');
+  htmlTest('html/core-ajax-arrays.html');
 });


### PR DESCRIPTION
convert each value candidate to string params into a json string before
go into encoreURIComponent

Used JSON.stringify, which according to http://caniuse.com/#search=JSON
is available in every browser without restriction since IE9

Added test for that, but can't run them since there is missing parts for
running them from the sources
