### PR TITLE
Allow easy override of params setup for components that extend from core-ajax

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -286,6 +286,14 @@ element.
       }
     },
 
+    getParams: function(params) {
+      params = this.params || params;
+      if (params && typeof(params) == 'string') {
+        params = JSON.parse(params);
+      }
+      return params;
+    },
+
     /**
      * Performs an Ajax request to the specified URL.
      *
@@ -295,10 +303,7 @@ element.
       var args = this.xhrArgs || {};
       // TODO(sjmiles): we may want XHR to default to POST if body is set
       args.body = this.body || args.body;
-      args.params = this.params || args.params;
-      if (args.params && typeof(args.params) == 'string') {
-        args.params = JSON.parse(args.params);
-      }
+      args.params = this.getParams(args.params);
       args.headers = this.headers || args.headers || {};
       if (args.headers && typeof(args.headers) == 'string') {
         args.headers = JSON.parse(args.headers);


### PR DESCRIPTION
There may be situations where you have an API token that needs to be sent with every request in your application, or, in the case of Ruby on Rails when doing CSRF protection, a CSRF token. Instead of including these configuration options in every core-ajax element that I add to my application, I would like to be able to extend core-ajax and only overwrite the params initialization logic in the `go` function without having to overwrite the entire thing. This change introduces that ability.

Example usage: https://gist.github.com/jhuckabee/810552e99959eacbbea9
