### PR TITLE
Extend auto's behavior to send requests on body change.

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -20,7 +20,7 @@ The `core-ajax` element exposes `XMLHttpRequest` functionality.
         on-core-response="{{handleResponse}}"></core-ajax>
 
 With `auto` set to `true`, the element performs a request whenever
-its `url` or `params` properties are changed.
+its `url`, `params` or `body` properties are changed.
 
 Note: The `params` attribute must be double quoted JSON.
 


### PR DESCRIPTION
Extends the behavior of `auto` to include core-ajax's body attribute.
