### PR TITLE
fix(form-data): `contentType` property must be null when sending `FormData` payload

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -367,7 +367,7 @@ element.
       var hasContentType = Object.keys(args.headers).some(function (header) {
         return header.toLowerCase() === 'content-type';
       });
-      // No Content-Type should be specified is sending `FormData`.  
+      // No Content-Type should be specified if sending `FormData`.  
       // The UA must set the Content-Type w/ a calculated  multipart boundary ID.
       if (args.body instanceof FormData) {
         delete args.headers['Content-Type'];


### PR DESCRIPTION
fixes #5
