### PR TITLE
Allow params with any HTTP request method

### DIFF
--- a/core-xhr.html
+++ b/core-xhr.html
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var async = !options.sync;
         //
         var params = this.toQueryString(options.params);
-        if (params && method == 'GET') {
+        if (params) {
           url += (url.indexOf('?') > 0 ? '&' : '?') + params;
         }
         var xhrParams = this.isBodyMethod(method) ? (options.body || params) : null;


### PR DESCRIPTION
The given params should be used with any request method.
