### PR TITLE
Fix demo-progress reload button

### DIFF
--- a/demo-progress.html
+++ b/demo-progress.html
@@ -27,12 +27,12 @@
         https://github.com/kennethreitz/httpbin/pull/160
        -->
       <div>
-        <button on-click="{{restart}}">Restart</button>
         <template if="{{loading}}">
           Loading...
         </template>
         <template if="{{!loading}}">
           Loaded!
+          <button on-click="{{restart}}">Restart</button>
         </template>
       </div>
       <template if="{{loading && progress.loaded}}">


### PR DESCRIPTION
There is no abort() method on core-ajax (maybe it was removed?)
