### PR TITLE
Removing the condition which would return status as successful

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -236,7 +236,7 @@ element.
 
     isSuccess: function(xhr) {
       var status = xhr.status || 0;
-      return !status || (status >= 200 && status < 300);
+      return status >= 200 && status < 300;
     },
 
     processResponse: function(xhr) {


### PR DESCRIPTION
If there is no status on the call, the call should not be considered as successful. 
For example when the back-end server is not responding although there was a `ERR_CONNECTION_RESET` but still the `core-response` was being fire instead of `core-error`. This was as the result of status being `0` and and `!0` would return `true` for `isSuccess`
