### PR TITLE
Remove bad status check in isSuccess

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -236,7 +236,7 @@ element.
 
     isSuccess: function(xhr) {
       var status = xhr.status || 0;
-      return !status || (status >= 200 && status < 300);
+      return (status >= 200 && status < 300);
     },
 
     processResponse: function(xhr) {


### PR DESCRIPTION
See https://github.com/Polymer/core-ajax/issues/58

The `return` statement that I modified seems like it shouldn't be necessary to be any more complicated than the one step that I left. The `!status` was causing any `status` equal to `0` to return `true`.