### PR TITLE
Fix error processing for other responseTypes than 'text'

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -248,7 +248,10 @@ element.
     },
 
     processError: function(xhr) {
-      var response = xhr.status + ': ' + xhr.responseText;
+      var response = xhr.status;
+      if (response.responseType === '' || response.responseType === 'text') {
+        response += ': ' + xhr.responseText;
+      }
       if (xhr === this.activeRequest) {
         this.error = response;
       }


### PR DESCRIPTION
Prevents DOMException:
Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was 'document').