### PR TITLE
Errors are now eval'ed like normal responses

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -249,10 +249,14 @@ element.
 
     processError: function(xhr) {
       var response = this.evalResponse(xhr);
+      var error = {
+        statusCode: xhr.status,
+        response: response
+      };
       if (xhr === this.activeRequest) {
-        this.error = response;
+        this.error = error;
       }
-      this.fire('core-error', {response: response, xhr: xhr});
+      this.fire('core-error', {response: error, xhr: xhr});
     },
 
     processProgress: function(progress, xhr) {

--- a/core-ajax.html
+++ b/core-ajax.html
@@ -248,7 +248,7 @@ element.
     },
 
     processError: function(xhr) {
-      var response = xhr.status + ': ' + xhr.responseText;
+      var response = this.evalResponse(xhr);
       if (xhr === this.activeRequest) {
         this.error = response;
       }


### PR DESCRIPTION
Errors are now handled as normal responses i. e. they are evaluated and parsed according to the format specified by handleAs (shameless plug: This would work even better if pull request Polymer/core-ajax#62 also was implemented).

See also: Polymer/core-ajax#31