### PR TITLE
processError handling

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -248,11 +248,11 @@ element.
     },
 
     processError: function(xhr) {
-      var response = xhr.status + ': ' + xhr.responseText;
+      var response = this.evalResponse(xhr);
       if (xhr === this.activeRequest) {
         this.error = response;
       }
-      this.fire('core-error', {response: response, xhr: xhr});
+      this.fire('core-error', {response: response, status: xhr.status, xhr: xhr});
     },
 
     processProgress: function(progress, xhr) {


### PR DESCRIPTION
processError doesn't respond the same as processResponse. Errors aren't currently encoded whereas normal responses are, this changes the behavior so that the two behave in the same consistent way except process error now passes back a status object with the error code.
