### PR TITLE
Add listener for upload progress

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -392,6 +392,7 @@ element.
       args.callback = this.receive.bind(this);
       args.url = this.url;
       args.method = this.method;
+      args.onProgress = this.processProgress.bind(this);
 
       this.response = this.error = this.progress = null;
       this.activeRequest = args.url && this.xhr.request(args);
@@ -399,13 +400,7 @@ element.
         this.loading = true;
         var activeRequest = this.activeRequest;
         // IE < 10 doesn't support progress events.
-        if ('onprogress' in activeRequest) {
-          this.activeRequest.addEventListener(
-              'progress',
-              function(progress) {
-                this.processProgress(progress, activeRequest);
-              }.bind(this), false);
-        } else {
+        if (!('onprogress' in activeRequest)) {
           this.progress = {
             lengthComputable: false,
           }

--- a/core-xhr.html
+++ b/core-xhr.html
@@ -56,6 +56,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         var xhrParams = this.isBodyMethod(method) ? (options.body || params) : null;
         //
+
+        if (options.onProgress) {
+          if ('onprogress' in xhr) {
+            xhr.addEventListener('progress', function (progress) {
+              options.onProgress(progress, xhr);
+            }, false);
+            xhr.upload.addEventListener('progress', function (progress) {
+              options.onProgress(progress, xhr);
+            }, false);
+          }
+        }
+
         xhr.open(method, url, async);
         if (options.responseType) {
           xhr.responseType = options.responseType;


### PR DESCRIPTION
As per [this document](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress), progress listeners should be set before calling `xhr.open()`. This PR addresses that and also adds a listener for uploads, instead of only downloads.
