### PR TITLE
Make `lastResponse` and `lastError` race-free.

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -231,8 +231,7 @@ element.
       },
 
       /**
-       * Will be set to true if there is at least one in-flight request
-       * associated with this core-ajax element.
+       * True while `lastRequest` is in progress.
        *
        * @attribute loading
        * @type boolean
@@ -258,10 +257,11 @@ element.
       },
 
       /**
-       * Will be set to the most recent response received by a request
-       * that originated from this core-ajax element. The type of the response
-       * is determined by the value of `handleas` at the time that the request
-       * was generated.
+       * Will be set to the successful response received for `lastRequest`, if
+       * any. The type of the response is determined by the value of `handleas`
+       * at the time that the request was generated. While `lastRequest` hasn't
+       * completed, or if it received an error, then this attribute will be set
+       * to `undefined`.
        *
        * @attribute lastresponse
        * @type *
@@ -274,8 +274,9 @@ element.
       },
 
       /**
-       * Will be set to the most recent error that resulted from a request
-       * that originated from this core-ajax element.
+       * Will be set to the error received for `lastRequest`, if any. While
+       * `lastRequest` hasn't completed, or if it resolved successfully, then
+       * this attribute will be set to `undefined`.
        *
        * @attribute lasterror
        * @type Error
@@ -308,14 +309,6 @@ element.
     observers: {
       'url method headers contentType body sync handleAs withCredentials':
         'requestOptionsChanged'
-    },
-
-    configure: function() {
-      return {
-        _boundHandleResponse: this.handleResponse.bind(this),
-        _boundHandleError: this.handleError.bind(this),
-        _boundDiscardRequest: this.discardRequest.bind(this)
-      };
     },
 
     get queryString () {
@@ -386,17 +379,21 @@ element.
 
       this.activeRequests.push(request);
 
-      request.completes.then(
-        this._boundHandleResponse
-      ).catch(
-        this._boundHandleError
-      ).then(
-        this._boundDiscardRequest
-      );
+      var self = this;
+      request.completes.then(function(response) {
+        self.handleResponse(request, response);
+      }).catch(function(error) {
+        self.handleError(request, error);
+      }).then(function() {
+        self.discardRequest(request);
+      });
 
       request.send(requestOptions);
 
       this._setLastRequest(request);
+      this._setLastError(undefined);
+      this._setLastResponse(undefined);
+      this._setLoading(true);
 
       this.fire('request', {
         xhr: request.xhr,
@@ -406,24 +403,31 @@ element.
       return request;
     },
 
-    handleResponse: function(response) {
-      this._setLastResponse(response);
+    handleResponse: function(request, response) {
+      if (request === this.lastRequest) {
+        this._setLastError(undefined);
+        this._setLastResponse(response);
+        this._setLoading(false);
+      }
       this.fire('response', response);
     },
 
-    handleError: function(error) {
+    handleError: function(request, error) {
       if (this.verbose) {
         console.error(error);
       }
-
-      this._setLastError(error);
+      if (request === this.lastRequest) {
+        this._setLastError(error);
+        this._setLastResponse(undefined);
+        this._setLoading(false);
+      }
       this.fire('error', error);
     },
 
     discardRequest: function(request) {
       var requestIndex = this.activeRequests.indexOf(request);
 
-      if (requestIndex > 0) {
+      if (requestIndex >= 0) {
         this.activeRequests.splice(requestIndex, 1);
       }
     }

--- a/test/core-ajax.html
+++ b/test/core-ajax.html
@@ -50,6 +50,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var request;
       var server;
 
+      // A stand-in for Promise.all, as promise-polyfill doesn't polyfill it.
+      function promiseAll(promises) {
+        promises = promises.slice(); // defensive copy
+        return new Promise(function(resolve, reject) {
+          var i = 0;
+          var onSuccess = function() {
+            i++;
+            if (i == promises.length) {
+              resolve();
+            };
+          };
+          var onFailure = function() {
+            reject();
+          };
+          for (var i = 0; i < promises.length; i++) {
+            promises[i].then(onSuccess, onFailure);
+          }
+        });
+      }
+
       setup(function () {
         server = sinon.fakeServer.create();
         server.respondWith(
@@ -137,7 +157,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             requests.push(echoRequest.generateRequest());
           }
           var allPromises = requests.map(function(r){return r.completes});
-          promiseAllComplete = Promise.all(allPromises);
+          promiseAllComplete = promiseAll(allPromises);
         });
 
         test('holds outstanding requests in the `activeRequests` Array',

--- a/test/core-ajax.html
+++ b/test/core-ajax.html
@@ -30,6 +30,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <core-ajax auto url="/responds_to_get_with_json"></core-ajax>
     </template>
   </test-fixture>
+  <test-fixture id="GetEcho">
+    <template>
+      <core-ajax handleas="json" url="/echoes_request_url"></core-ajax>
+    </template>
+  </test-fixture>
   <test-fixture id="TrivialPost">
     <template>
       <core-ajax method="POST"
@@ -74,6 +79,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         server.restore();
       });
 
+      function respondToEchoRequest(request) {
+        request.respond(200, jsonResponseHeaders, JSON.stringify({
+          url: request.url
+        }));
+      }
+
       suite('when making simple GET requests for JSON', function () {
         test('has sane defaults that love you', function () {
           request = ajax.generateRequest();
@@ -115,17 +126,81 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('when there are multiple requests', function () {
         var requests;
-
+        var echoRequest;
+        var promiseAllComplete;
         setup(function () {
+          echoRequest = fixture('GetEcho');
           requests = [];
 
           for (var i = 0; i < 3; ++i) {
-            requests.push(ajax.generateRequest());
+            echoRequest.params = {'order': i + 1};
+            requests.push(echoRequest.generateRequest());
           }
+          var allPromises = requests.map(function(r){return r.completes});
+          promiseAllComplete = Promise.all(allPromises);
         });
 
-        test('holds all requests in the `activeRequests` Array', function () {
-          expect(requests).to.deep.eql(ajax.activeRequests);
+        test('holds outstanding requests in the `activeRequests` Array',
+          function(done) {
+            expect(echoRequest.activeRequests).to.deep.eql(requests);
+            server.respond();
+            promiseAllComplete.then(function() {
+              setTimeout(function() {
+                try {
+                  expect(echoRequest.activeRequests).to.deep.eql([]);
+                  done();
+                } catch(e) {
+                  done(e);
+                }
+              }, 1);
+            });
+          }
+        );
+
+        test('avoids race conditions with last response', function(done) {
+          expect(echoRequest.lastResponse).to.be.equal(undefined);
+
+          // Resolving the oldest request doesn't update lastResponse.
+          respondToEchoRequest(server.requests[0]);
+          requests[0].completes.then(function() {
+            expect(echoRequest.lastResponse).to.be.equal(undefined);
+
+            // Resolving the most recent request does!
+            respondToEchoRequest(server.requests[2]);
+            return requests[2].completes;
+          }).then(function() {
+            expect(echoRequest.lastResponse).to.be.deep.eql(
+                {url: '/echoes_request_url?order=3'});
+
+            // Resolving an out of order stale request after does nothing!
+            respondToEchoRequest(server.requests[1]);
+            return requests[1].completes;
+          }).then(function() {
+            expect(echoRequest.lastResponse).to.be.deep.eql(
+                {url: '/echoes_request_url?order=3'});
+          }).then(done, done);
+        });
+
+        test('`loading` is true while the last one is loading', function(done) {
+          expect(echoRequest.loading).to.be.equal(true);
+
+          // Still loading when the oldest request resolves.
+          respondToEchoRequest(server.requests[0]);
+          requests[0].completes.then(function() {
+            expect(echoRequest.loading).to.be.equal(true);
+
+            // Finished loading after the newest one resolves though.
+            respondToEchoRequest(server.requests[2]);
+            return requests[2].completes;
+          }).then(function() {
+            expect(echoRequest.loading).to.be.eql(false);
+
+            // Resolving an out of order stale request after does nothing.
+            respondToEchoRequest(server.requests[1]);
+            return requests[1].completes;
+          }).then(function() {
+            expect(echoRequest.loading).to.be.eql(false);
+          }).then(done, done);
         });
       });
 

--- a/test/core-ajax.html
+++ b/test/core-ajax.html
@@ -54,10 +54,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       function promiseAll(promises) {
         promises = promises.slice(); // defensive copy
         return new Promise(function(resolve, reject) {
-          var i = 0;
+          var successes = 0;
           var onSuccess = function() {
-            i++;
-            if (i == promises.length) {
+            successes++;
+            if (successes >= promises.length) {
               resolve();
             };
           };


### PR DESCRIPTION
Fixes #77

Also hook up the `loading` attribute and fix an error where the oldest
request would never be discarded from `activeRequests`.