### PR TITLE
removed {{}} from on-response call

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -16,7 +16,8 @@ The `core-ajax` element exposes network request functionality.
         url="http://gdata.youtube.com/feeds/api/videos/"
         params='{"alt":"json", "q":"chrome"}'
         handleas="json"
-        on-response="{{handleResponse}}"></core-ajax>
+        on-response="handleResponse"
+    ></core-ajax>
 
 With `auto` set to `true`, the element performs a request whenever
 its `url`, `params` or `body` properties are changed. Automatically generated


### PR DESCRIPTION
Hey, this is my first attempt at contributing to Polymer! 

Per [0.8 docs](https://www.polymer-project.org/0.8/docs/migration.html#declarative-handlers), declarative handlers no longer use curly brackets.
