### PR TITLE
[0.8] fix observers

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -305,17 +305,14 @@ element.
       }
     },
 
-    observers: {
-      'url method headers contentType body sync handleAs withCredentials':
-        'requestOptionsChanged'
-    },
+    observers: [
+      'requestOptionsChanged(url, method, headers, contentType, body, sync, handleAs, withCredentials, auto)'
+    ],
 
-    configure: function() {
-      return {
-        _boundHandleResponse: this.handleResponse.bind(this),
-        _boundHandleError: this.handleError.bind(this),
-        _boundDiscardRequest: this.discardRequest.bind(this)
-      };
+    created: function() {
+      this._boundHandleResponse = this.handleResponse.bind(this);
+      this._boundHandleError = this.handleError.bind(this);
+      this._boundDiscardRequest = this.discardRequest.bind(this);
     },
 
     get queryString () {


### PR DESCRIPTION
In this PR:

Update to use methods signature based `observers` array.
Hookup handler bindings in `created` event since `configure` is no longer being called.

Now works with current Polymer 0.8-preview branch.
