### PR TITLE
Remove mixed content vulnerability in demo-progress.html

### DIFF
--- a/demo-progress.html
+++ b/demo-progress.html
@@ -12,7 +12,7 @@
     <template>
       <core-ajax
           id="ajax" auto
-          url="http://httpbin.org/drip"
+          url="//httpbin.org/drip"
           params="{{ {numbytes: numbytes, duration:5} }}"
           response="{{response}}"
           progress="{{progress}}"


### PR DESCRIPTION
Using http:// in demo-progress.html causes a mixed content vulnerability which, among other undesirable effects, causes Chrome not to load the data until explicitly told to load unsafe scripts.